### PR TITLE
add go-offline-maven-plugin plugin

### DIFF
--- a/postgres-consumer-app/pom.xml
+++ b/postgres-consumer-app/pom.xml
@@ -67,6 +67,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>de.qaware.maven</groupId>
+			<artifactId>go-offline-maven-plugin</artifactId>
+			<version>1.2.8</version>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -74,6 +79,35 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>de.qaware.maven</groupId>
+				<artifactId>go-offline-maven-plugin</artifactId>
+				<version>1.2.8</version>
+				<configuration>
+					<dynamicDependencies>
+						<DynamicDependency>
+							<groupId>org.apache.maven.surefire</groupId>
+							<artifactId>surefire-junit4</artifactId>
+							<version>2.20.1</version>
+							<repositoryType>PLUGIN</repositoryType>
+						</DynamicDependency>
+						<DynamicDependency>
+							<groupId>com.querydsl</groupId>
+							<artifactId>querydsl-apt</artifactId>
+							<version>4.2.1</version>
+							<classifier>jpa</classifier>
+							<repositoryType>MAIN</repositoryType>
+						</DynamicDependency>
+						<DynamicDependency>
+							<groupId>org.flywaydb</groupId>
+							<artifactId>flyway-commandline</artifactId>
+							<version>4.0.3</version>
+							<type>zip</type>
+							<repositoryType>MAIN</repositoryType>
+						</DynamicDependency>
+					</dynamicDependencies>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
this is related to PR: https://github.gwd.broadcom.net/TNZ/postgres-tile/pull/138

this plugin is needed in order to download
all depdencies that are necessary for an
offline build.

without this, by using the builtin offline
build from maven, we would see the following
error:

Could not resolve dependencies for project com.example:postgres-demo:jar:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.apache.commons:commons-lang3:jar:3.12.0 (absent), org.jboss.logging:jboss-logging:jar:3.4.2.Final (absent), org.glassfish.jaxb:jaxb-runtime:jar:2.3.5 (absent), net.minidev:json-smart:jar:2.4.7 (absent), net.bytebuddy:byte-buddy-agent:jar:1.10.22 (absent): Cannot access esd-blazesv-maven-virtual (https://usw1.packages.broadcom.com/artifactory/esd-blazesv-maven-virtual) in offline mode and the artifact org.apache.commons:commons-lang3:jar:3.12.0 has not been downloaded from it before.